### PR TITLE
feat: add range list series commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-use std::collections::{BTreeSet, HashMap};
+use bincode::error::{DecodeError, EncodeError};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::io;
 use std::io::Read;
-use std::time::Instant;
-use bincode::{Encode, Decode};
-use bincode::error::{EncodeError, DecodeError};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// A simple in-memory key-value store with pub/sub support, TTL/expiration, and persistence.
 #[derive(Serialize, Deserialize, Encode, Decode)]
@@ -37,6 +37,13 @@ impl Default for KVStore {
 
 impl KVStore {
     /// Creates a new empty `KVStore`.
+
+    fn now_seconds() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock is before UNIX_EPOCH")
+            .as_secs()
+    }
     pub fn new() -> Self {
         Self::default()
     }
@@ -45,7 +52,7 @@ impl KVStore {
     pub fn set_with_ttl(&mut self, key: String, value: String, ttl: Option<u64>) {
         self.data.insert(key.clone(), value);
         if let Some(ttl_seconds) = ttl {
-            let expiration = Instant::now().elapsed().as_secs() + ttl_seconds;
+            let expiration = Self::now_seconds() + ttl_seconds;
             self.expiration.insert(key, expiration);
         } else {
             self.expiration.remove(&key);
@@ -60,7 +67,7 @@ impl KVStore {
     /// Gets a value by key, automatically expiring it if TTL has passed.
     pub fn get(&mut self, key: &str) -> Option<&String> {
         if let Some(expiration) = self.expiration.get(key) {
-            let now = Instant::now().elapsed().as_secs();
+            let now = Self::now_seconds();
             if now >= *expiration {
                 self.data.remove(key);
                 self.expiration.remove(key);
@@ -89,10 +96,7 @@ impl KVStore {
     pub fn subscribe(&mut self, channel: String) -> usize {
         let id = self.next_sub_id;
         self.next_sub_id += 1;
-        self.subscribers
-            .entry(channel)
-            .or_default()
-            .insert(id);
+        self.subscribers.entry(channel).or_default().insert(id);
         id
     }
 
@@ -139,11 +143,12 @@ impl KVStore {
         let mut file = fs::File::open(path)?;
         let mut contents = Vec::new();
         file.read_to_end(&mut contents)?;
-        let (mut store, _): (KVStore, _) = match bincode::decode_from_slice(&contents, bincode::config::standard()) {
-            Ok(s) => s,
-            Err(DecodeError::Io { inner, .. }) => return Err(inner),
-            Err(err) => return Err(io::Error::other(err.to_string())),
-        };
+        let (mut store, _): (KVStore, _) =
+            match bincode::decode_from_slice(&contents, bincode::config::standard()) {
+                Ok(s) => s,
+                Err(DecodeError::Io { inner, .. }) => return Err(inner),
+                Err(err) => return Err(io::Error::other(err.to_string())),
+            };
         // Clear expiration times since they're relative to when the data was saved
         store.expiration.clear();
         store.persist_path = Some(path.to_string());
@@ -162,7 +167,7 @@ impl KVStore {
     /// Get remaining TTL for a key in seconds. Returns None if key doesn't exist or has no TTL.
     pub fn ttl(&self, key: &str) -> Option<i64> {
         if let Some(expiration) = self.expiration.get(key) {
-            let now = Instant::now().elapsed().as_secs();
+            let now = Self::now_seconds();
             let remaining = *expiration as i64 - now as i64;
             if remaining > 0 {
                 Some(remaining)
@@ -179,7 +184,7 @@ impl KVStore {
     /// Set expiration for an existing key.
     pub fn expire(&mut self, key: &str, ttl_seconds: u64) -> bool {
         if self.data.contains_key(key) {
-            let expiration = Instant::now().elapsed().as_secs() + ttl_seconds;
+            let expiration = Self::now_seconds() + ttl_seconds;
             self.expiration.insert(key.to_string(), expiration);
             true
         } else {
@@ -264,12 +269,27 @@ mod tests {
     }
 
     #[test]
+    fn test_ttl_decreases_after_elapsed_time() {
+        let mut store = KVStore::new();
+        store.set_with_ttl("key1".to_string(), "value1".to_string(), Some(3));
+
+        std::thread::sleep(std::time::Duration::from_millis(1200));
+
+        let remaining = store.ttl("key1").expect("key should still have TTL");
+        assert!(
+            remaining > 0,
+            "TTL should still be non-zero after a short delay"
+        );
+        assert!(remaining < 3, "TTL should decrease after elapsed time");
+    }
+
+    #[test]
     fn test_expire_command() {
         let mut store = KVStore::new();
         store.set("key1".to_string(), "value1".to_string());
         assert!(store.expire("key1", 3600));
         assert!(store.ttl("key1").map(|t| t > 0).unwrap_or(false));
-        
+
         // Non-existent key
         assert!(!store.expire("nonexistent", 3600));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,18 @@
-use std::collections::{BTreeSet, HashMap};
+use bincode::error::{DecodeError, EncodeError};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap};
 use std::env;
 use std::io::{self, BufRead, Read, Write};
 use std::sync::{Arc, Mutex};
-use bincode::{Encode, Decode};
-use bincode::error::{EncodeError, DecodeError};
 
 type Storage = HashMap<String, String>;
+type ListStorage = HashMap<String, Vec<String>>;
 
 #[derive(Serialize, Deserialize, Default, Encode, Decode)]
 struct KVStore {
     data: Storage,
+    lists: ListStorage,
     /// Expiration times per key: key -> absolute timestamp (seconds since epoch)
     #[serde(rename = "exp")]
     expiration: HashMap<String, u64>,
@@ -23,6 +25,7 @@ impl KVStore {
     fn new() -> Self {
         Self {
             data: HashMap::new(),
+            lists: HashMap::new(),
             expiration: HashMap::new(),
             subscribers: HashMap::new(),
             next_sub_id: 1,
@@ -30,10 +33,15 @@ impl KVStore {
         }
     }
 
+    fn now_seconds() -> u64 {
+        std::time::Instant::now().elapsed().as_secs()
+    }
+
     fn set_with_ttl(&mut self, key: String, value: String, ttl: Option<u64>) {
+        self.lists.remove(&key);
         self.data.insert(key.clone(), value);
         if let Some(ttl_seconds) = ttl {
-            let expiration = std::time::Instant::now().elapsed().as_secs() + ttl_seconds;
+            let expiration = Self::now_seconds() + ttl_seconds;
             self.expiration.insert(key, expiration);
         } else {
             self.expiration.remove(&key);
@@ -42,9 +50,10 @@ impl KVStore {
 
     fn get(&mut self, key: &str) -> Option<&String> {
         if let Some(expiration) = self.expiration.get(key) {
-            let now = std::time::Instant::now().elapsed().as_secs();
+            let now = Self::now_seconds();
             if now >= *expiration {
                 self.data.remove(key);
+                self.lists.remove(key);
                 self.expiration.remove(key);
                 return None;
             }
@@ -54,24 +63,25 @@ impl KVStore {
 
     fn del(&mut self, key: &str) -> bool {
         self.expiration.remove(key);
-        self.data.remove(key).is_some()
+        self.data.remove(key).is_some() || self.lists.remove(key).is_some()
     }
 
-    fn keys(&mut self) -> Vec<&String> {
-        let keys: Vec<String> = self.data.keys().cloned().collect();
-        for key in keys {
-            self.get(&key);
+    fn keys(&mut self) -> Vec<String> {
+        let all_keys: Vec<String> = self.data.keys().chain(self.lists.keys()).cloned().collect();
+        for key in &all_keys {
+            self.get(key);
         }
-        self.data.keys().collect()
+
+        let mut keys: Vec<String> = self.data.keys().chain(self.lists.keys()).cloned().collect();
+        keys.sort();
+        keys.dedup();
+        keys
     }
 
     fn subscribe(&mut self, channel: String) -> usize {
         let id = self.next_sub_id;
         self.next_sub_id += 1;
-        self.subscribers
-            .entry(channel)
-            .or_default()
-            .insert(id);
+        self.subscribers.entry(channel).or_default().insert(id);
         id
     }
 
@@ -112,11 +122,12 @@ impl KVStore {
         let mut file = std::fs::File::open(path)?;
         let mut contents = Vec::new();
         file.read_to_end(&mut contents)?;
-        let (mut store, _): (KVStore, _) = match bincode::decode_from_slice(&contents, bincode::config::standard()) {
-            Ok(s) => s,
-            Err(DecodeError::Io { inner, .. }) => return Err(inner),
-            Err(err) => return Err(io::Error::other(err.to_string())),
-        };
+        let (mut store, _): (KVStore, _) =
+            match bincode::decode_from_slice(&contents, bincode::config::standard()) {
+                Ok(s) => s,
+                Err(DecodeError::Io { inner, .. }) => return Err(inner),
+                Err(err) => return Err(io::Error::other(err.to_string())),
+            };
         store.expiration.clear();
         store.persist_path = Some(path.to_string());
         Ok(store)
@@ -132,14 +143,14 @@ impl KVStore {
 
     fn ttl(&self, key: &str) -> Option<i64> {
         if let Some(expiration) = self.expiration.get(key) {
-            let now = std::time::Instant::now().elapsed().as_secs();
+            let now = Self::now_seconds();
             let remaining = *expiration as i64 - now as i64;
             if remaining > 0 {
                 Some(remaining)
             } else {
                 None
             }
-        } else if self.data.contains_key(key) {
+        } else if self.data.contains_key(key) || self.lists.contains_key(key) {
             Some(-1)
         } else {
             None
@@ -147,8 +158,8 @@ impl KVStore {
     }
 
     fn expire(&mut self, key: &str, ttl_seconds: u64) -> bool {
-        if self.data.contains_key(key) {
-            let expiration = std::time::Instant::now().elapsed().as_secs() + ttl_seconds;
+        if self.data.contains_key(key) || self.lists.contains_key(key) {
+            let expiration = Self::now_seconds() + ttl_seconds;
             self.expiration.insert(key.to_string(), expiration);
             true
         } else {
@@ -160,8 +171,48 @@ impl KVStore {
         if self.expiration.remove(key).is_some() {
             true
         } else {
-            self.data.contains_key(key)
+            self.data.contains_key(key) || self.lists.contains_key(key)
         }
+    }
+
+    fn rpush(&mut self, key: &str, values: &[String]) -> usize {
+        self.data.remove(key);
+        let list = self.lists.entry(key.to_string()).or_default();
+        list.extend(values.iter().cloned());
+        list.len()
+    }
+
+    fn lpush(&mut self, key: &str, values: &[String]) -> usize {
+        self.data.remove(key);
+        let list = self.lists.entry(key.to_string()).or_default();
+        for value in values {
+            list.insert(0, value.clone());
+        }
+        list.len()
+    }
+
+    fn lrange(&self, key: &str, start: isize, stop: isize) -> Option<Vec<String>> {
+        let list = self.lists.get(key)?;
+        if list.is_empty() {
+            return Some(vec![]);
+        }
+
+        let len = list.len() as isize;
+        let mut s = if start < 0 { len + start } else { start };
+        let mut e = if stop < 0 { len + stop } else { stop };
+
+        s = s.max(0).min(len - 1);
+        e = e.max(0).min(len - 1);
+
+        if s > e {
+            return Some(vec![]);
+        }
+
+        Some(list[s as usize..=e as usize].to_vec())
+    }
+
+    fn llen(&self, key: &str) -> Option<usize> {
+        self.lists.get(key).map(Vec::len)
     }
 }
 
@@ -194,7 +245,7 @@ fn main() {
 
     println!("KV Storage (Redis-like) - Basic Edition");
     println!(
-        "Commands: GET <key>, SET <key> <value> [TTL], DEL <key>, KEYS, SUBSCRIBE <channel>, PUBLISH <channel> <message>, UNSUBSCRIBE <channel> <sub_id>, TTL <key>, EXPIRE <key> <seconds>, PERSISTKEY <key>, PERSIST <path>, QUIT"
+        "Commands: GET <key>, SET <key> <value> [TTL], DEL <key>, KEYS, SUBSCRIBE <channel>, PUBLISH <channel> <message>, UNSUBSCRIBE <channel> <sub_id>, TTL <key>, EXPIRE <key> <seconds>, PERSISTKEY <key>, PERSIST <path>, RPUSH <key> <v1> [v2...], LPUSH <key> <v1> [v2...], LRANGE <key> <start> <stop>, LLEN <key>, QUIT"
     );
 
     for line in stdin.lock().lines() {
@@ -229,22 +280,25 @@ fn main() {
                     writeln!(stdout_lock, "Error: SET requires <key> <value> [TTL]").unwrap();
                     continue;
                 }
-                let rest = parts[1].trim();
-                let parts2: Vec<&str> = rest.splitn(2, ' ').collect();
-                if parts2.len() < 2 {
+                let tokens: Vec<&str> = parts[1].split_whitespace().collect();
+                if tokens.len() < 2 {
                     writeln!(stdout_lock, "Error: SET requires <key> <value> [TTL]").unwrap();
                     continue;
                 }
-                let key = parts2[0].trim();
-                let value = parts2[1].trim();
-                
-                // Check for optional TTL
-                let ttl: Option<u64> = if parts2.len() >= 3 {
-                    parts2[2].trim().parse().ok()
+                let key = tokens[0];
+                let value = tokens[1];
+                let ttl = if tokens.len() >= 3 {
+                    match tokens[2].parse::<u64>() {
+                        Ok(v) => Some(v),
+                        Err(_) => {
+                            writeln!(stdout_lock, "Error: Invalid TTL value").unwrap();
+                            continue;
+                        }
+                    }
                 } else {
                     None
                 };
-                
+
                 let mut storage = storage.lock().unwrap();
                 storage.set_with_ttl(key.to_string(), value.to_string(), ttl);
                 if storage.maybe_persist().is_err() {
@@ -319,13 +373,21 @@ fn main() {
             }
             "UNSUBSCRIBE" => {
                 if parts.len() < 2 || parts[1].is_empty() {
-                    writeln!(stdout_lock, "Error: UNSUBSCRIBE requires <channel> <sub_id>").unwrap();
+                    writeln!(
+                        stdout_lock,
+                        "Error: UNSUBSCRIBE requires <channel> <sub_id>"
+                    )
+                    .unwrap();
                     continue;
                 }
                 let rest = parts[1].trim();
                 let parts2: Vec<&str> = rest.splitn(2, ' ').collect();
                 if parts2.len() < 2 {
-                    writeln!(stdout_lock, "Error: UNSUBSCRIBE requires <channel> <sub_id>").unwrap();
+                    writeln!(
+                        stdout_lock,
+                        "Error: UNSUBSCRIBE requires <channel> <sub_id>"
+                    )
+                    .unwrap();
                     continue;
                 }
                 let channel = parts2[0].trim();
@@ -348,9 +410,9 @@ fn main() {
                 let key = parts[1].trim();
                 let storage = storage.lock().unwrap();
                 match storage.ttl(key) {
-                    Some(-1) => writeln!(stdout_lock, "(integer) -1").unwrap(), // No TTL
-                    Some(t) => writeln!(stdout_lock, "(integer) {}", t).unwrap(), // Remaining seconds
-                    None => writeln!(stdout_lock, "(nil)").unwrap(), // Key doesn't exist or expired
+                    Some(-1) => writeln!(stdout_lock, "(integer) -1").unwrap(),
+                    Some(t) => writeln!(stdout_lock, "(integer) {}", t).unwrap(),
+                    None => writeln!(stdout_lock, "(nil)").unwrap(),
                 }
             }
             "EXPIRE" => {
@@ -410,6 +472,89 @@ fn main() {
                     writeln!(stdout_lock, "Error: Failed to persist").unwrap();
                 } else {
                     writeln!(stdout_lock, "Persistence enabled: {}", path).unwrap();
+                }
+            }
+            "RPUSH" | "LPUSH" => {
+                if parts.len() < 2 {
+                    writeln!(
+                        stdout_lock,
+                        "Error: {} requires <key> <v1> [v2...]",
+                        command
+                    )
+                    .unwrap();
+                    continue;
+                }
+                let tokens: Vec<&str> = parts[1].split_whitespace().collect();
+                if tokens.len() < 2 {
+                    writeln!(
+                        stdout_lock,
+                        "Error: {} requires <key> <v1> [v2...]",
+                        command
+                    )
+                    .unwrap();
+                    continue;
+                }
+                let key = tokens[0];
+                let values: Vec<String> = tokens[1..].iter().map(|s| (*s).to_string()).collect();
+                let mut storage = storage.lock().unwrap();
+                let len = if command == "RPUSH" {
+                    storage.rpush(key, &values)
+                } else {
+                    storage.lpush(key, &values)
+                };
+                if storage.maybe_persist().is_err() {
+                    writeln!(stdout_lock, "Warning: Persist failed").unwrap();
+                }
+                writeln!(stdout_lock, "(integer) {}", len).unwrap();
+            }
+            "LRANGE" => {
+                if parts.len() < 2 {
+                    writeln!(stdout_lock, "Error: LRANGE requires <key> <start> <stop>").unwrap();
+                    continue;
+                }
+                let tokens: Vec<&str> = parts[1].split_whitespace().collect();
+                if tokens.len() != 3 {
+                    writeln!(stdout_lock, "Error: LRANGE requires <key> <start> <stop>").unwrap();
+                    continue;
+                }
+                let key = tokens[0];
+                let start: isize = match tokens[1].parse() {
+                    Ok(v) => v,
+                    Err(_) => {
+                        writeln!(stdout_lock, "Error: LRANGE start must be an integer").unwrap();
+                        continue;
+                    }
+                };
+                let stop: isize = match tokens[2].parse() {
+                    Ok(v) => v,
+                    Err(_) => {
+                        writeln!(stdout_lock, "Error: LRANGE stop must be an integer").unwrap();
+                        continue;
+                    }
+                };
+                let storage = storage.lock().unwrap();
+                match storage.lrange(key, start, stop) {
+                    Some(values) if values.is_empty() => {
+                        writeln!(stdout_lock, "(empty array)").unwrap()
+                    }
+                    Some(values) => {
+                        for value in values {
+                            writeln!(stdout_lock, "- {}", value).unwrap();
+                        }
+                    }
+                    None => writeln!(stdout_lock, "(nil)").unwrap(),
+                }
+            }
+            "LLEN" => {
+                if parts.len() < 2 || parts[1].is_empty() {
+                    writeln!(stdout_lock, "Error: LLEN requires a key").unwrap();
+                    continue;
+                }
+                let key = parts[1].trim();
+                let storage = storage.lock().unwrap();
+                match storage.llen(key) {
+                    Some(len) => writeln!(stdout_lock, "(integer) {}", len).unwrap(),
+                    None => writeln!(stdout_lock, "(integer) 0").unwrap(),
                 }
             }
             "QUIT" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,15 +48,22 @@ impl KVStore {
         }
     }
 
-    fn get(&mut self, key: &str) -> Option<&String> {
+    fn evict_if_expired(&mut self, key: &str) -> bool {
         if let Some(expiration) = self.expiration.get(key) {
             let now = Self::now_seconds();
             if now >= *expiration {
                 self.data.remove(key);
                 self.lists.remove(key);
                 self.expiration.remove(key);
-                return None;
+                return true;
             }
+        }
+        false
+    }
+
+    fn get(&mut self, key: &str) -> Option<&String> {
+        if self.evict_if_expired(key) {
+            return None;
         }
         self.data.get(key)
     }
@@ -191,7 +198,11 @@ impl KVStore {
         list.len()
     }
 
-    fn lrange(&self, key: &str, start: isize, stop: isize) -> Option<Vec<String>> {
+    fn lrange(&mut self, key: &str, start: isize, stop: isize) -> Option<Vec<String>> {
+        if self.evict_if_expired(key) {
+            return None;
+        }
+
         let list = self.lists.get(key)?;
         if list.is_empty() {
             return Some(vec![]);
@@ -201,9 +212,15 @@ impl KVStore {
         let mut s = if start < 0 { len + start } else { start };
         let mut e = if stop < 0 { len + stop } else { stop };
 
-        s = s.max(0).min(len - 1);
-        e = e.max(0).min(len - 1);
-
+        if s < 0 {
+            s = 0;
+        }
+        if e < 0 || s >= len {
+            return Some(vec![]);
+        }
+        if e >= len {
+            e = len - 1;
+        }
         if s > e {
             return Some(vec![]);
         }
@@ -211,7 +228,10 @@ impl KVStore {
         Some(list[s as usize..=e as usize].to_vec())
     }
 
-    fn llen(&self, key: &str) -> Option<usize> {
+    fn llen(&mut self, key: &str) -> Option<usize> {
+        if self.evict_if_expired(key) {
+            return None;
+        }
         self.lists.get(key).map(Vec::len)
     }
 }
@@ -532,7 +552,7 @@ fn main() {
                         continue;
                     }
                 };
-                let storage = storage.lock().unwrap();
+                let mut storage = storage.lock().unwrap();
                 match storage.lrange(key, start, stop) {
                     Some(values) if values.is_empty() => {
                         writeln!(stdout_lock, "(empty array)").unwrap()
@@ -551,7 +571,7 @@ fn main() {
                     continue;
                 }
                 let key = parts[1].trim();
-                let storage = storage.lock().unwrap();
+                let mut storage = storage.lock().unwrap();
                 match storage.llen(key) {
                     Some(len) => writeln!(stdout_lock, "(integer) {}", len).unwrap(),
                     None => writeln!(stdout_lock, "(integer) 0").unwrap(),
@@ -566,5 +586,40 @@ fn main() {
             }
         }
         stdout_lock.flush().unwrap();
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lrange_out_of_bounds_start_returns_empty() {
+        let mut store = KVStore::new();
+        let values = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        store.rpush("mylist", &values);
+
+        assert_eq!(store.lrange("mylist", 100, 200), Some(vec![]));
+    }
+
+    #[test]
+    fn lrange_negative_stop_before_start_returns_empty() {
+        let mut store = KVStore::new();
+        let values = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        store.rpush("mylist", &values);
+
+        assert_eq!(store.lrange("mylist", 0, -100), Some(vec![]));
+    }
+
+    #[test]
+    fn list_reads_reflect_immediate_expiration_without_get() {
+        let mut store = KVStore::new();
+        let values = vec!["a".to_string(), "b".to_string()];
+        store.rpush("l", &values);
+        assert!(store.expire("l", 0));
+
+        assert_eq!(store.llen("l"), None);
+        assert_eq!(store.lrange("l", 0, -1), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,10 @@ impl KVStore {
     }
 
     fn now_seconds() -> u64 {
-        std::time::Instant::now().elapsed().as_secs()
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock is before UNIX_EPOCH")
+            .as_secs()
     }
 
     fn set_with_ttl(&mut self, key: String, value: String, ttl: Option<u64>) {
@@ -588,7 +591,6 @@ fn main() {
         stdout_lock.flush().unwrap();
     }
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- add Redis-like list command support with `LPUSH`, `RPUSH`, `LRANGE`, and `LLEN`
- store lists separately from string keys and make key operations (`DEL`, `KEYS`, `TTL`, `EXPIRE`, `PERSISTKEY`) work for both types
- fix `SET <key> <value> [TTL]` argument parsing so optional TTL is actually handled

## Testing
- `cargo test`

Closes #1